### PR TITLE
Move Private Jimp Method to Public Static Util Class

### DIFF
--- a/camera/security-camera/src/util/hotspot-utils.ts
+++ b/camera/security-camera/src/util/hotspot-utils.ts
@@ -4,7 +4,7 @@
 
 import { HotspotBoundingBox } from '../model/hotspot-bounding-box';
 
-export class Hotspot {
+export class HotspotUtils {
   /**
    * Check if a parsed hotspot used for motion sensing is within bounds of thumbnail width/height.
    * @param hotspot - a hotspot to check if valid or not
@@ -50,16 +50,16 @@ export class Hotspot {
     const hotspots = boxStrings.map((boxString: string) => {
       const boxSplit = boxString.split(',');
       const hotspot: HotspotBoundingBox = {
-        left: Hotspot.hotspotPercentToPixels(Number(boxSplit[0]), imageWidth),
-        top: Hotspot.hotspotPercentToPixels(Number(boxSplit[1]), imageHeight),
-        width: Hotspot.hotspotPercentToPixels(Number(boxSplit[2]), imageWidth),
-        height: Hotspot.hotspotPercentToPixels(Number(boxSplit[3]), imageHeight)
+        left: HotspotUtils.hotspotPercentToPixels(Number(boxSplit[0]), imageWidth),
+        top: HotspotUtils.hotspotPercentToPixels(Number(boxSplit[1]), imageHeight),
+        width: HotspotUtils.hotspotPercentToPixels(Number(boxSplit[2]), imageWidth),
+        height: HotspotUtils.hotspotPercentToPixels(Number(boxSplit[3]), imageHeight)
       };
       return hotspot;
     })
 
     // Filter out anything not right.
-    .filter((hotspot: HotspotBoundingBox) => Hotspot.hotspotIsValid(hotspot, imageWidth, imageHeight));
+    .filter((hotspot: HotspotBoundingBox) => HotspotUtils.hotspotIsValid(hotspot, imageWidth, imageHeight));
 
     // Set hotspots used when calculating motion detection.
     if (hotspots.length > 0) {

--- a/camera/security-camera/src/util/jimp-utils.ts
+++ b/camera/security-camera/src/util/jimp-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Utils for handling motion hotspot bounding boxes used for motion detection in images.
+ */
+
+import Jimp from 'jimp';
+
+export class JimpUtils {
+  
+  /**
+   * Get the RGB distance of two images for a given pixel, used for pixel comparison.
+   * @param image1 - first image to use for pixel "distance"
+   * @param image2 - second image of equal width/height of image1 to use for pixel "distance"
+   * @param pixelX - x coordinate in pixels to read in both images
+   * @param pixelY - y coordinate in pixels to read in both images
+   */
+  public static getPixelRgbDistanceRatio = (image1: Jimp, image2: Jimp, pixelX: number, pixelY: number) => {
+    // Set a max distance value to use as a multiplier.
+    // Math.sqrt(Math.pow(255,2) + Math.pow(255,2) + Math.pow(255,2))
+    const maxDistance = 441.6729559300637;
+    
+    // Get RGB values from both images at the same pixel x/y
+    const image1Rgb = Jimp.intToRGBA(image1.getPixelColor(pixelX, pixelY));
+    const image2Rgb = Jimp.intToRGBA(image2.getPixelColor(pixelX, pixelY));
+    const distance = Math.sqrt(
+      Math.pow(image1Rgb.r - image2Rgb.r, 2) + 
+      Math.pow(image1Rgb.g - image2Rgb.g, 2) + 
+      Math.pow(image1Rgb.b - image2Rgb.b, 2)
+    );
+
+    return distance === 0 ? 0 : (distance / maxDistance);
+  }
+}


### PR DESCRIPTION
In an effort to make code test ready before proceeding much
further (TDD is good for me, DDT did no one good), move the
private Jimp-related pixel distance method to a new public
util class.

Refactor hotspot-util naming to match.