### PR TITLE
Refactor: Enable Testing, Move Static Methods, Bug Fixes, Optimizations

### DIFF
--- a/camera/security-camera/Dockerfile.template
+++ b/camera/security-camera/Dockerfile.template
@@ -34,7 +34,7 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-node
 WORKDIR /usr/src/app
 
 # Install packages
-RUN install_packages libraspberrypi-bin
+RUN install_packages libraspberrypi-bin exiv2
 
 # Copy needed files in root to the working directory in the container
 COPY --from=build /usr/src/app/dist dist

--- a/camera/security-camera/package.json
+++ b/camera/security-camera/package.json
@@ -7,20 +7,28 @@
     "serve": "node dist/server.js",
     "build": "npm run build-ts && npm run lint",
     "build-ts": "tsc",
-    "lint": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix"
+    "lint": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
+    "test": "mocha -r ts-node/register src/**/*.spec.ts"
   },
   "author": "Christopher L. Stevens (chris@interactive.guru)",
   "license": "ISC",
   "devDependencies": {
+    "@types/chai": "^4.2.11",
+    "@types/chokidar": "^2.1.3",
     "@types/lodash": "^4.14.149",
+    "@types/mocha": "^7.0.2",
+    "@types/mv": "^2.1.0",
     "@types/node": "^13.9.8",
+    "@types/sinon": "^9.0.0",
+    "@types/uuid": "^7.0.2",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
+    "chai": "^4.2.0",
     "eslint": "^6.8.0",
-    "typescript": "^3.8.3",
-    "@types/chokidar": "^2.1.3",
-    "@types/mv": "^2.1.0",
-    "@types/uuid": "^7.0.2"
+    "mocha": "^7.1.1",
+    "sinon": "^9.0.2",
+    "ts-node": "^8.8.2",
+    "typescript": "^3.8.3"
   },
   "dependencies": {
     "dotenv": "^8.2.0",

--- a/camera/security-camera/src/util/cmd-utils.spec.ts
+++ b/camera/security-camera/src/util/cmd-utils.spec.ts
@@ -1,0 +1,47 @@
+import sinon from 'sinon';
+import child_process from 'child_process';
+import stream from 'stream';
+import events from 'events';
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import { CmdUtils } from './cmd-utils';
+
+describe("CmdUtils: spawnAsPromise", () => {
+  // Thanks: https://stackoverflow.com/questions/26839932/how-to-mock-the-node-js-child-process-spawn-function
+  it("should run successfully", async() => {
+      const sandbox = sinon.createSandbox();
+      try {
+          const CMD = 'foo';
+          const ARGS = ['--bar'];
+          const OPTS = { cwd: '/var/fubar' };
+
+          const STDERR_TEXT = 'Some diag stuff...';
+          const STDOUT_TEXT = 'Some output stuff...';
+
+          const proc = <child_process.ChildProcess> new events.EventEmitter();
+          proc.stdout = <stream.Readable> new events.EventEmitter();
+          proc.stderr = <stream.Readable> new events.EventEmitter();
+
+          // Stub out child process, returning our fake child process
+          sandbox.stub(child_process, 'spawn')
+              .returns(proc)    
+              .calledOnceWith(CMD, ARGS, OPTS);
+
+          // Launch process
+          const p = CmdUtils.spawnAsPromise(CMD, ARGS);
+
+          // Simulate spawn output
+          proc.stderr.emit('data', STDERR_TEXT);
+          proc.stdout.emit('data', STDOUT_TEXT);
+
+          // Exit program, 0 = success, !0 = failure
+          proc.emit('close', 0);
+
+          // The close should get rid of the process
+          const results = await p;
+          assert.equal(results, STDERR_TEXT + STDOUT_TEXT);
+      } finally {
+          sandbox.restore();
+      }
+  });
+});

--- a/camera/security-camera/src/util/cmd-utils.ts
+++ b/camera/security-camera/src/util/cmd-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * 
+ */
+
+import { spawn } from 'child_process';
+
+export class CmdUtils {
+  // Return child_process.spawn as a promise.
+  // Thank you: https://stackoverflow.com/questions/26839932/how-to-mock-the-node-js-child-process-spawn-function
+  public static spawnAsPromise = (cmd: string, args: ReadonlyArray<string>): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      let output: string = '';  
+      const child = spawn(cmd, args);
+      child.stdout.on('data', (data) => {
+          output += data;
+      });
+      child.stderr.on('data', (data) => {
+          output += data;
+      });
+      child.on('close', (code) => {
+          (code === 0) ? resolve(output) : reject(output);
+      });
+      child.on('exit', (code) => {
+        (code === 0) ? resolve(output) : reject(output);
+      });
+      child.on('error', (err) => {
+          reject(err.toString());
+      });
+    });
+  }
+}

--- a/camera/security-camera/src/util/jimp-utils.ts
+++ b/camera/security-camera/src/util/jimp-utils.ts
@@ -29,4 +29,17 @@ export class JimpUtils {
 
     return distance === 0 ? 0 : (distance / maxDistance);
   }
+
+  /**
+   * Load an image file and return as a Jimp class image that can be used in Node.
+   * @param imagePath - full path to image file
+   */
+  public static loadImage = async (imagePath: string) => {
+    try {
+      return await Jimp.read(imagePath);
+    } catch (err) {
+      console.log('loadImage error', err);
+      throw new Error('Unable to load image');
+    }
+  }
 }


### PR DESCRIPTION
Add mocha, chai, ts-node and sinon for testing purposes. Add a
first test. Move spawn commands in raspistill-manager and motion-
capturer to shared class static method. Move image loading method
to JimpUtils. Fix the process stack interval that wasn't running.
Enable chokidar polling to reduce CPU usage when tracking a small
RAM directory from a constant 20-60% to about 5%.