### PR TITLE
Create Code Coverage Github Action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,27 @@
+name: Code Coverage
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Test and Publish Code Coverage
+      uses: paambaati/codeclimate-action@v2.5.6
+      env:
+        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      with:
+        # The report file must be there, otherwise Code Climate won't find it
+        coverageCommand: cd camera/security-camera && npm test
+        coverageLocations:
+          "${{github.workspace}}/camera/security-camera/coverage"


### PR DESCRIPTION
Create a Github Action that tests code and sends an Icov code coverage report to Code Climate.