### PR TITLE
Correct Docker Compose Volume Config, Removing Repeat Errors at balena.io

### DIFF
--- a/camera/docker-compose.yml
+++ b/camera/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   security-camera:
     build: ./security-camera
     volumes:
-      - 'image-temp:/image-temp'
-      - 'image-ready:/image-ready'
+      - image-temp:/image-temp
+      - image-ready:/image-ready
     devices:
       - /dev/vchiq:/dev/vchiq
     environment:


### PR DESCRIPTION
Resolve this error: "Error creating volume 'image-temp' due to
'Trying to create volume with name: image-temp, but a volume
with that name and a different configuration already exists'