### PR TITLE
Resolve Volume Creation Error and Reset Delay

### DIFF
--- a/camera/docker-compose.yml
+++ b/camera/docker-compose.yml
@@ -2,19 +2,18 @@ version: '2'
 volumes:
   # This RAM drive is for raspicam to place a constant stream of images while not
   # burning out MicroSD card, pending motion detection and move to image-ready.
-  image-temp:
+  tmp:
     driver_opts:
       type: tmpfs
       device: tmpfs
-      # 64MB (in bytes)
-      size: 67108864
+      o: "size=67108864"
   # Images are stored here when motion is detected, ready for upload when possible.
   image-ready:
 services:
   security-camera:
     build: ./security-camera
     volumes:
-      - 'image-temp:/image-temp'
+      - 'tmp:/image-temp'
       - 'image-ready:/image-ready'
     devices:
       - /dev/vchiq:/dev/vchiq


### PR DESCRIPTION
There was an issue where restarting the camera app via balena.io
either by reset or new version update would have a ten minute
or so delay. There was also a volume create error that was related.
Correct the template per helpful feedback from balena team to
resolve these issues.